### PR TITLE
Include sonarcloud analysis in build process -> for some reason, the …

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -11,7 +11,8 @@ phases:
   build:
     commands:
       - mvn install
-      - mvn sonar:sonar -Dsonar.login=$SONAR_LOGIN -Dsonar.projectBaseDir=$(pwd)
+      - git init
+      - mvn sonar:sonar -Dsonar.login=$SONAR_LOGIN
   post_build:
     commands:
       - aws s3 rm --recursive "s3://codepipeline-eu-central-1-623791722169/grocery-tracker-back/SourceArti"

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,6 @@
 		<sonar.projectKey>khyiu_grocery-tracker-back</sonar.projectKey>
 		<sonar.organization>khyiu</sonar.organization>
 		<sonar.host.url>https://sonarcloud.io</sonar.host.url>
-		<sonar.sources>src</sonar.sources>
 	</properties>
 
 	<dependencies>


### PR DESCRIPTION
…sonar scanner maven plugin absolutely required a git work tree, so, added "git init" to see if we'd be able to generate one during AWS build